### PR TITLE
Compare TextInputLayout's hint and error as String

### DIFF
--- a/kakao/src/main/kotlin/io/github/kakaocup/kakao/edit/TextInputLayoutAssertions.kt
+++ b/kakao/src/main/kotlin/io/github/kakaocup/kakao/edit/TextInputLayoutAssertions.kt
@@ -24,7 +24,7 @@ interface TextInputLayoutAssertions : BaseAssertions {
     fun hasHint(hint: String) {
         view.check(ViewAssertion { view, notFoundException ->
             if (view is TextInputLayout) {
-                if (hint != view.hint) {
+                if (hint != view.hint.toString()) {
                     throw AssertionError(
                         "Expected hint is $hint," +
                                 " but actual is ${view.hint}"
@@ -55,7 +55,7 @@ interface TextInputLayoutAssertions : BaseAssertions {
     fun hasError(error: String) {
         view.check(ViewAssertion { view, notFoundException ->
             if (view is TextInputLayout) {
-                if (error != view.error) {
+                if (error != view.error.toString()) {
                     throw AssertionError(
                         "Expected error is $error," +
                                 " but actual is ${view.error}"

--- a/sample/src/main/kotlin/io/github/kakaocup/sample/TextInputLayoutActivity.kt
+++ b/sample/src/main/kotlin/io/github/kakaocup/sample/TextInputLayoutActivity.kt
@@ -1,6 +1,10 @@
 package io.github.kakaocup.sample
 
+import android.graphics.Color
 import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
 import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.textfield.TextInputLayout
@@ -15,8 +19,8 @@ class TextInputLayoutActivity : AppCompatActivity() {
             isHintEnabled = true
             isErrorEnabled = true
             counterMaxLength = 50
-            hint = resources.getString(R.string.hint)
-            error = resources.getString(R.string.error)
+            hint = getSpannableHint()
+            error = getSpannableError()
         }
 
         findViewById<Button>(R.id.toggle_counter).setOnClickListener {
@@ -33,6 +37,18 @@ class TextInputLayoutActivity : AppCompatActivity() {
 
         findViewById<Button>(R.id.clean_error).setOnClickListener {
             layout.error = null
+        }
+    }
+
+    private fun getSpannableHint(): Spannable {
+        return SpannableString(resources.getString(R.string.hint)).apply {
+            setSpan(ForegroundColorSpan(Color.RED), 12, 16, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+    }
+
+    private fun getSpannableError(): Spannable {
+        return SpannableString(resources.getString(R.string.error)).apply {
+            setSpan(ForegroundColorSpan(Color.GREEN), 12, 17, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
     }
 }

--- a/sample/src/main/kotlin/io/github/kakaocup/sample/TextInputLayoutActivity.kt
+++ b/sample/src/main/kotlin/io/github/kakaocup/sample/TextInputLayoutActivity.kt
@@ -9,6 +9,7 @@ import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.textfield.TextInputLayout
 
+@SuppressWarnings("MagicNumber")
 class TextInputLayoutActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
See #49
The initial idea was to change `hasError()` and `hasHint()` methods signature and alter argument type from `String` to `CharSequence`,  but since we can't be sure that `CharSequence`'s implementation will override `equals()` method, the safest way to check that `TextInputLayout` has proper hint and error text is just to check the text equality.