### PR TITLE
Change espresso core to an api dependency.

### DIFF
--- a/kakao/build.gradle.kts
+++ b/kakao/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     implementation(Libraries.viewpager2)
     implementation(Libraries.swiperefresh)
     implementation(Libraries.design)
-    implementation(Libraries.espresso_core)
+    api(Libraries.espresso_core)
     implementation(Libraries.espresso_web)
     implementation(Libraries.espresso_intents)
     implementation(Libraries.espresso_contrib)


### PR DESCRIPTION
Else this leads to unresovled references in the IDE as Espresso is part of the public api, for example in:

```kotlin
fun click(location: GeneralLocation = GeneralLocation.VISIBLE_CENTER)
```

in BaseActions