### PR TITLE
Add support for gravity, text size, typeface for text view

### DIFF
--- a/kakao/src/main/kotlin/io/github/kakaocup/kakao/common/matchers/TextSizeMatcher.kt
+++ b/kakao/src/main/kotlin/io/github/kakaocup/kakao/common/matchers/TextSizeMatcher.kt
@@ -1,0 +1,22 @@
+package io.github.kakaocup.kakao.common.matchers
+
+import android.content.Context
+import android.util.TypedValue
+import android.view.View
+import android.widget.TextView
+import androidx.test.espresso.matcher.BoundedMatcher
+import kotlin.math.roundToInt
+import org.hamcrest.Description
+
+class TextSizeMatcher(private val textSizeInSp: Int) : BoundedMatcher<View, TextView>(TextView::class.java) {
+    override fun describeTo(description: Description) {
+        description.appendText("Text size doesn't match")
+    }
+
+    override fun matchesSafely(item: TextView): Boolean =
+        item.textSize.roundToInt() == spToPx(item.context, textSizeInSp)
+
+    private fun spToPx(context: Context, sp: Int): Int =
+        TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, sp.toFloat(), context.resources.displayMetrics)
+            .roundToInt()
+}

--- a/kakao/src/main/kotlin/io/github/kakaocup/kakao/common/matchers/TextViewGravityMatcher.kt
+++ b/kakao/src/main/kotlin/io/github/kakaocup/kakao/common/matchers/TextViewGravityMatcher.kt
@@ -1,0 +1,28 @@
+package io.github.kakaocup.kakao.common.matchers
+
+import android.view.Gravity
+import android.view.View
+import android.widget.TextView
+import androidx.test.espresso.matcher.BoundedMatcher
+import org.hamcrest.Description
+
+class TextViewGravityMatcher(
+    private val horizontalGravity: Int?,
+    private val verticalGravity: Int?,
+) : BoundedMatcher<View, TextView>(TextView::class.java) {
+
+    override fun describeTo(description: Description) {
+        description.appendText("Gravity doesn't match")
+    }
+
+    override fun matchesSafely(item: TextView): Boolean {
+        var compareResult = true
+        if (horizontalGravity != null) {
+            compareResult = compareResult && item.gravity and Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK == horizontalGravity
+        }
+        if (verticalGravity != null) {
+            compareResult = compareResult && item.gravity and Gravity.VERTICAL_GRAVITY_MASK == verticalGravity
+        }
+        return compareResult
+    }
+}

--- a/kakao/src/main/kotlin/io/github/kakaocup/kakao/common/matchers/TypefaceMatcher.kt
+++ b/kakao/src/main/kotlin/io/github/kakaocup/kakao/common/matchers/TypefaceMatcher.kt
@@ -1,0 +1,16 @@
+package io.github.kakaocup.kakao.common.matchers
+
+import android.graphics.Typeface
+import android.view.View
+import android.widget.TextView
+import androidx.test.espresso.matcher.BoundedMatcher
+import org.hamcrest.Description
+
+class TypefaceMatcher(private val typeface: Typeface) : BoundedMatcher<View, TextView>(TextView::class.java) {
+    override fun describeTo(description: Description) {
+        description.appendText("Typeface doesn't match")
+    }
+
+    override fun matchesSafely(item: TextView): Boolean =
+        item.typeface.equals(this.typeface)
+}

--- a/kakao/src/main/kotlin/io/github/kakaocup/kakao/text/TextViewAssertions.kt
+++ b/kakao/src/main/kotlin/io/github/kakaocup/kakao/text/TextViewAssertions.kt
@@ -2,6 +2,7 @@
 
 package io.github.kakaocup.kakao.text
 
+import android.graphics.Typeface
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
@@ -10,6 +11,9 @@ import androidx.test.espresso.matcher.ViewMatchers
 import io.github.kakaocup.kakao.common.assertions.BaseAssertions
 import io.github.kakaocup.kakao.common.matchers.AnyTextMatcher
 import io.github.kakaocup.kakao.common.matchers.CompoundDrawableMatcher
+import io.github.kakaocup.kakao.common.matchers.TextSizeMatcher
+import io.github.kakaocup.kakao.common.matchers.TextViewGravityMatcher
+import io.github.kakaocup.kakao.common.matchers.TypefaceMatcher
 import org.hamcrest.CoreMatchers
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers
@@ -197,6 +201,46 @@ interface TextViewAssertions : BaseAssertions {
         view.check(
             ViewAssertions.matches(
                 CompoundDrawableMatcher(left, top, right, bottom)
+            )
+        )
+    }
+
+    /**
+     * Checks if the view has given gravity
+     *
+     * @param horizontalGravity relative horizontal gravity values to be matched
+     * @param verticalGravity vertical gravity values to be matched
+     */
+    fun hasGravity(horizontalGravity: Int? = null, verticalGravity: Int? = null) {
+        view.check(
+            ViewAssertions.matches(
+                TextViewGravityMatcher(horizontalGravity, verticalGravity)
+            )
+        )
+    }
+
+    /**
+     * Checks if the view has text size in sp
+     *
+     * @param sp Text size in sp to be matched
+     */
+    fun hasTextSize(sp: Int) {
+        view.check(
+            ViewAssertions.matches(
+                TextSizeMatcher(sp)
+            )
+        )
+    }
+
+    /**
+     * Checks if the view has given typeface
+     *
+     * @param typeface TextView typeface to be matched
+     */
+    fun hasTypeface(typeface: Typeface) {
+        view.check(
+            ViewAssertions.matches(
+                TypefaceMatcher(typeface)
             )
         )
     }

--- a/sample/src/androidTest/kotlin/io/github/kakaocup/sample/TextViewTest.kt
+++ b/sample/src/androidTest/kotlin/io/github/kakaocup/sample/TextViewTest.kt
@@ -1,5 +1,13 @@
 package io.github.kakaocup.sample
 
+import android.graphics.Typeface
+import android.view.Gravity.BOTTOM
+import android.view.Gravity.CENTER
+import android.view.Gravity.CENTER_HORIZONTAL
+import android.view.Gravity.CENTER_VERTICAL
+import android.view.Gravity.END
+import android.view.Gravity.START
+import android.view.Gravity.TOP
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import io.github.kakaocup.kakao.screen.Screen
@@ -22,6 +30,41 @@ class TextViewTest {
             textViewWithTopDrawable.hasCompoundDrawable(top = R.drawable.ic_android_black_24dp)
             textViewWithBottomDrawable.hasCompoundDrawable(bottom = R.drawable.ic_android_black_24dp)
             textViewPlain.hasCompoundDrawable()
+        }
+    }
+
+    @Test
+    fun textTextGravity() {
+        Screen.onScreen<TextScreen> {
+            textViewCentered.hasGravity(horizontalGravity = CENTER_HORIZONTAL)
+            textViewOnStart.hasGravity(horizontalGravity = START)
+            textViewOnEnd.hasGravity(horizontalGravity = END)
+            textViewOnTop.hasGravity(verticalGravity = TOP)
+            textViewOnBottom.hasGravity(verticalGravity = BOTTOM)
+            textViewOnTopLeft.hasGravity(horizontalGravity = START, verticalGravity = TOP)
+            textViewOnBottomRight.hasGravity(horizontalGravity = END, verticalGravity = BOTTOM)
+            textViewHorizontalCenteredTop.hasGravity(horizontalGravity = CENTER_HORIZONTAL, verticalGravity = TOP)
+            textViewVerticalCenteredEnd.hasGravity(horizontalGravity = END, verticalGravity = CENTER_VERTICAL)
+        }
+    }
+
+    @Test
+    fun textTextSize() {
+        Screen.onScreen<TextScreen> {
+            textViewSize14Sp.hasTextSize(14)
+            textViewSize19Sp.hasTextSize(19)
+            textViewSize32Sp.hasTextSize(32)
+        }
+    }
+
+    @Test
+    fun textTextTypeface() {
+        Screen.onScreen<TextScreen> {
+            textViewTypefaceNormal.hasTypeface(Typeface.DEFAULT)
+            textViewTypefaceMonospace.hasTypeface(Typeface.MONOSPACE)
+            textViewTypefaceNormalBold.hasTypeface(Typeface.DEFAULT_BOLD)
+            textViewTypefaceSansItalic.hasTypeface(Typeface.create("sans", Typeface.ITALIC))
+            textViewTypefaceSerifBoldItalic.hasTypeface(Typeface.create("serif", Typeface.BOLD_ITALIC))
         }
     }
 }

--- a/sample/src/androidTest/kotlin/io/github/kakaocup/sample/screen/TextScreen.kt
+++ b/sample/src/androidTest/kotlin/io/github/kakaocup/sample/screen/TextScreen.kt
@@ -10,4 +10,24 @@ class TextScreen : Screen<TextScreen>() {
     val textViewWithRightDrawable = KTextView { withId(R.id.text_view_drawable_right) }
     val textViewWithTopDrawable = KTextView { withId(R.id.text_view_drawable_top) }
     val textViewWithBottomDrawable = KTextView { withId(R.id.text_view_drawable_bottom) }
+
+    val textViewCentered = KTextView { withId(R.id.text_view_gravity_center) }
+    val textViewOnStart = KTextView { withId(R.id.text_view_gravity_start) }
+    val textViewOnEnd = KTextView { withId(R.id.text_view_gravity_end) }
+    val textViewOnTop = KTextView { withId(R.id.text_view_gravity_top) }
+    val textViewOnBottom = KTextView { withId(R.id.text_view_gravity_bottom) }
+    val textViewOnTopLeft = KTextView { withId(R.id.text_view_gravity_top_left) }
+    val textViewOnBottomRight = KTextView { withId(R.id.text_view_gravity_bottom_right) }
+    val textViewHorizontalCenteredTop = KTextView { withId(R.id.text_view_gravity_horizontal_center_top) }
+    val textViewVerticalCenteredEnd = KTextView { withId(R.id.text_view_gravity_vertical_center_end) }
+
+    val textViewSize14Sp = KTextView { withId(R.id.text_view_size_14sp) }
+    val textViewSize19Sp = KTextView { withId(R.id.text_view_size_19sp) }
+    val textViewSize32Sp = KTextView { withId(R.id.text_view_size_32sp) }
+
+    val textViewTypefaceNormal = KTextView { withId(R.id.text_view_typeface_normal) }
+    val textViewTypefaceMonospace = KTextView { withId(R.id.text_view_typeface_monospace) }
+    val textViewTypefaceNormalBold = KTextView { withId(R.id.text_view_typeface_normal_bold) }
+    val textViewTypefaceSansItalic = KTextView { withId(R.id.text_view_typeface_sans_italic) }
+    val textViewTypefaceSerifBoldItalic = KTextView { withId(R.id.text_view_typeface_serif_bold_italic) }
 }

--- a/sample/src/main/res/layout/activity_text.xml
+++ b/sample/src/main/res/layout/activity_text.xml
@@ -1,41 +1,178 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-  <TextView
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:text="Just a text"
-      android:id="@+id/plain_text_view"/>
+  <ScrollView
+      android:layout_width="match_parent"
+      android:layout_height="match_parent">
 
-  <TextView
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:text="Drawable left"
-      android:drawableLeft="@drawable/ic_android_black_24dp"
-      android:id="@+id/text_view_drawable_left"/>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-  <TextView
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:text="Drawable right"
-      android:drawableRight="@drawable/ic_android_black_24dp"
-      android:id="@+id/text_view_drawable_right"/>
+      <TextView
+          android:id="@+id/plain_text_view"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="Just a text" />
 
-  <TextView
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:text="Drawable top"
-      android:drawableTop="@drawable/ic_android_black_24dp"
-      android:id="@+id/text_view_drawable_top"/>
+      <TextView
+          android:id="@+id/text_view_drawable_left"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:drawableLeft="@drawable/ic_android_black_24dp"
+          android:text="Drawable left" />
 
-  <TextView
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:text="Drawable bottom"
-      android:drawableBottom="@drawable/ic_android_black_24dp"
-      android:id="@+id/text_view_drawable_bottom"/>
+      <TextView
+          android:id="@+id/text_view_drawable_right"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:drawableRight="@drawable/ic_android_black_24dp"
+          android:text="Drawable right" />
 
-</LinearLayout>
+      <TextView
+          android:id="@+id/text_view_drawable_top"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:drawableTop="@drawable/ic_android_black_24dp"
+          android:text="Drawable top" />
+
+      <TextView
+          android:id="@+id/text_view_drawable_bottom"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:drawableBottom="@drawable/ic_android_black_24dp"
+          android:text="Drawable bottom" />
+
+      <TextView
+          android:id="@+id/text_view_gravity_center"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:gravity="center"
+          android:text="Text centered" />
+
+      <TextView
+          android:id="@+id/text_view_gravity_start"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:gravity="start"
+          android:text="Text on start" />
+
+      <TextView
+          android:id="@+id/text_view_gravity_end"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:gravity="end"
+          android:text="Text on end" />
+
+      <TextView
+          android:id="@+id/text_view_gravity_top"
+          android:layout_width="wrap_content"
+          android:layout_height="40dp"
+          android:background="@color/background_color"
+          android:gravity="top"
+          android:text="Text on top" />
+
+      <TextView
+          android:id="@+id/text_view_gravity_bottom"
+          android:layout_width="wrap_content"
+          android:layout_height="40dp"
+          android:background="@color/background_color"
+          android:gravity="bottom"
+          android:text="Text on bottom" />
+
+      <TextView
+          android:id="@+id/text_view_gravity_top_left"
+          android:layout_width="match_parent"
+          android:layout_height="40dp"
+          android:background="@color/background_color"
+          android:gravity="top|start"
+          android:text="Text on top left" />
+
+      <TextView
+          android:id="@+id/text_view_gravity_bottom_right"
+          android:layout_width="match_parent"
+          android:layout_height="40dp"
+          android:background="@color/background_color"
+          android:gravity="bottom|end"
+          android:text="Text on bottom right" />
+
+      <TextView
+          android:id="@+id/text_view_gravity_horizontal_center_top"
+          android:layout_width="match_parent"
+          android:layout_height="40dp"
+          android:background="@color/background_color"
+          android:gravity="center_horizontal|top"
+          android:text="Text on horizontal_center | top" />
+
+      <TextView
+          android:id="@+id/text_view_gravity_vertical_center_end"
+          android:layout_width="match_parent"
+          android:layout_height="40dp"
+          android:background="@color/background_color"
+          android:gravity="center_vertical|end"
+          android:text="Text on vertical_center | end" />
+
+      <TextView
+          android:id="@+id/text_view_size_14sp"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="Text 14sp"
+          android:textSize="14sp" />
+
+      <TextView
+          android:id="@+id/text_view_size_19sp"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="Text 19sp"
+          android:textSize="19sp" />
+
+      <TextView
+          android:id="@+id/text_view_size_32sp"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="Text 32sp"
+          android:textSize="32sp" />
+
+      <TextView
+          android:id="@+id/text_view_typeface_normal"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="Text normal typeface"
+          android:typeface="normal" />
+
+      <TextView
+          android:id="@+id/text_view_typeface_monospace"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="Text monospace typeface"
+          android:typeface="monospace" />
+
+      <TextView
+          android:id="@+id/text_view_typeface_normal_bold"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="Text normal &amp; bold typeface"
+          android:textStyle="bold"
+          android:typeface="normal" />
+
+      <TextView
+          android:id="@+id/text_view_typeface_sans_italic"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="Text sans &amp; italic typeface"
+          android:textStyle="italic"
+          android:typeface="sans" />
+
+      <TextView
+          android:id="@+id/text_view_typeface_serif_bold_italic"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="Text serif &amp; bold &amp; italic typeface"
+          android:textStyle="bold|italic"
+          android:typeface="serif" />
+    </LinearLayout>
+  </ScrollView>
+</merge>


### PR DESCRIPTION
Add common matchers:
- [TextSizeMatcher.kt](https://github.com/KakaoCup/Kakao/compare/master...hongwei-bai:add-text-styles-n-compound-drawables-verifications?expand=1#diff-b2f510793d46dcc0cce04894f1c72f46dd893243737c8ee81b17361e59166c87)
- [TextViewGravityMatcher.kt](https://github.com/KakaoCup/Kakao/compare/master...hongwei-bai:add-text-styles-n-compound-drawables-verifications?expand=1#diff-e69cec2a9196e3bca953a1529d96700895bc687d3ea7e13b59cfd3cea0c7ad3d)
- [TypefaceMatcher.kt](https://github.com/KakaoCup/Kakao/compare/master...hongwei-bai:add-text-styles-n-compound-drawables-verifications?expand=1#diff-fb972e8a9bdb2beed9e2b30b6a1d1aef7973e171226e3f1584eaebcfaade620f)

and  methods in [TextViewAssertions.kt](https://github.com/KakaoCup/Kakao/compare/master...hongwei-bai:add-text-styles-n-compound-drawables-verifications?expand=1#diff-4d0e851d1977b7ae662622e6b810a41bf5d3b533a4334b542281de036b1ebaf8)

samples:
<img src="https://user-images.githubusercontent.com/19883889/178900422-bb9f1e9d-16a0-4295-9711-5f0041e30f2c.png" width="240" height="500"/>
