### PR TITLE
Use dedicated ViewPager/ViewPager2 actions

### DIFF
--- a/kakao/src/main/kotlin/io/github/kakaocup/kakao/pager/KViewPager.kt
+++ b/kakao/src/main/kotlin/io/github/kakaocup/kakao/pager/KViewPager.kt
@@ -15,7 +15,7 @@ import org.hamcrest.Matcher
  * @see SwipeableActions
  * @see ViewPagerAssertions
  */
-class KViewPager : KBaseView<KViewPager>, SwipeableActions, ViewPagerAssertions {
+class KViewPager : KBaseView<KViewPager>, ViewPagerActions, ViewPagerAssertions {
     constructor(function: ViewBuilder.() -> Unit) : super(function)
     constructor(parent: Matcher<View>, function: ViewBuilder.() -> Unit) : super(parent, function)
     constructor(parent: DataInteraction, function: ViewBuilder.() -> Unit) : super(parent, function)

--- a/kakao/src/main/kotlin/io/github/kakaocup/kakao/pager/ViewPagerActions.kt
+++ b/kakao/src/main/kotlin/io/github/kakaocup/kakao/pager/ViewPagerActions.kt
@@ -1,0 +1,72 @@
+package io.github.kakaocup.kakao.pager
+
+import androidx.test.espresso.action.ViewActions
+import io.github.kakaocup.kakao.common.actions.BaseActions
+import io.github.kakaocup.kakao.common.actions.SwipeableActions
+import androidx.test.espresso.contrib.ViewPagerActions as EspressoViewPagerActions
+
+interface ViewPagerActions : BaseActions {
+
+    /**
+     * Swipes left on the view
+     */
+    @Deprecated(
+        "Use scrollRight()",
+        replaceWith = ReplaceWith("scrollRight()")
+    )
+    fun swipeLeft() {
+        view.perform(EspressoViewPagerActions.scrollRight(true))
+    }
+
+    /**
+     * Swipes right on the view
+     */
+    @Deprecated(
+        "Use scrollLeft()",
+        replaceWith = ReplaceWith("scrollLeft()")
+    )
+    fun swipeRight() {
+        view.perform(EspressoViewPagerActions.scrollLeft(true))
+    }
+
+    /**
+     * Swipes up on the view
+     */
+    @Deprecated("ViewPager doesn't support swipeUp action")
+    fun swipeUp() {
+        view.perform(ViewActions.swipeUp())
+    }
+
+    /**
+     * Swipes down on the view
+     */
+    @Deprecated("ViewPager doesn't support swipeDown action")
+    fun swipeDown() {
+        view.perform(ViewActions.swipeDown())
+    }
+
+    /** Moves <code>ViewPager</code> to the left be one page. */
+    fun scrollLeft() {
+        view.perform(EspressoViewPagerActions.scrollLeft())
+    }
+
+    /** Moves <code>ViewPager</code> to the right be one page. */
+    fun scrollRight() {
+        view.perform(EspressoViewPagerActions.scrollRight())
+    }
+
+    /** Moves <code>ViewPager</code> to the first page. */
+    fun scrollToFirst() {
+        view.perform(EspressoViewPagerActions.scrollToFirst())
+    }
+
+    /** Moves <code>ViewPager</code> to the last page. */
+    fun scrollToLast() {
+        view.perform(EspressoViewPagerActions.scrollToLast())
+    }
+
+    /** Moves <code>ViewPager</code> to a specific page. */
+    fun scrollToPage(page: Int) {
+        view.perform(EspressoViewPagerActions.scrollToPage(page))
+    }
+}

--- a/kakao/src/main/kotlin/io/github/kakaocup/kakao/pager2/ViewPager2Actions.kt
+++ b/kakao/src/main/kotlin/io/github/kakaocup/kakao/pager2/ViewPager2Actions.kt
@@ -51,6 +51,44 @@ interface ViewPager2Actions : ScrollableActions, SwipeableActions {
         })
     }
 
+    /**
+     * Scrolls to the next position of the view
+     */
+    fun scrollForward() {
+        view.perform(object : ViewAction {
+            override fun getDescription() = "Scroll view pager 2 forward"
+
+            override fun getConstraints() = ViewMatchers.isAssignableFrom(ViewPager2::class.java)
+
+            override fun perform(controller: UiController, view: View) {
+                if (view is ViewPager2) {
+                    val currentItem = view.currentItem
+                    view.setCurrentItem(currentItem + 1, false)
+                    controller.loopMainThreadUntilIdle()
+                }
+            }
+        })
+    }
+
+    /**
+     * Scrolls to the previous position of the view
+     */
+    fun scrollBackward() {
+        view.perform(object : ViewAction {
+            override fun getDescription() = "Scroll view pager 2 backward"
+
+            override fun getConstraints() = ViewMatchers.isAssignableFrom(ViewPager2::class.java)
+
+            override fun perform(controller: UiController, view: View) {
+                if (view is ViewPager2) {
+                    val currentItem = view.currentItem
+                    view.setCurrentItem(currentItem - 1, false)
+                    controller.loopMainThreadUntilIdle()
+                }
+            }
+        })
+    }
+
     override fun scrollTo(position: Int) {
         view.perform(object : ViewAction {
             override fun getDescription() = "Scroll view pager 2 to specific position"

--- a/sample/src/androidTest/kotlin/io/github/kakaocup/sample/Pager2Test.kt
+++ b/sample/src/androidTest/kotlin/io/github/kakaocup/sample/Pager2Test.kt
@@ -36,4 +36,62 @@ class Pager2Test {
           }
         }
     }
+
+    @Test
+    fun testViewPager2Scroll() {
+        Screen.onScreen<Pager2Screen> {
+            pager {
+                hasDescendant {
+                    withText("0")
+                    isCompletelyDisplayed()
+                }
+                scrollForward()
+                hasDescendant {
+                    withText("1")
+                    isCompletelyDisplayed()
+                }
+                scrollBackward()
+                hasDescendant {
+                    withText("0")
+                    isCompletelyDisplayed()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testViewPager2ScrollOverStartEdge() {
+        Screen.onScreen<Pager2Screen> {
+            pager {
+                scrollToStart()
+                hasDescendant {
+                    withText("0")
+                    isCompletelyDisplayed()
+                }
+                scrollBackward()
+                hasDescendant {
+                    withText("0")
+                    isCompletelyDisplayed()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testViewPager2ScrollOverEndEdge() {
+        Screen.onScreen<Pager2Screen> {
+            pager {
+                scrollToEnd()
+                hasDescendant {
+                    withText("5")
+                    isCompletelyDisplayed()
+                }
+                scrollForward()
+                hasDescendant {
+                    withText("5")
+                    isCompletelyDisplayed()
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
General `SwipeableActions` were used before that were not fully synchronized with ViewPager's state. Tests were flaky in rare conditions because of that.

Not to break public API I have added new methods. But IMO it would be good to get rid of `SwipeableActions` methods from `KViewPager` because:
- `ViewPager` doesn't support swipeDown/Up
- Are not fully synchronized by Espresso. Since swipe actions ends earlier then ViewPager settles. That makes tests flaky

closes #65