### PR TITLE
Make ScrollViewActions support horizontal and nested scroll views

### DIFF
--- a/kakao/src/main/kotlin/io/github/kakaocup/kakao/scroll/ScrollViewActions.kt
+++ b/kakao/src/main/kotlin/io/github/kakaocup/kakao/scroll/ScrollViewActions.kt
@@ -3,13 +3,17 @@
 package io.github.kakaocup.kakao.scroll
 
 import android.view.View
+import android.widget.HorizontalScrollView
 import android.widget.ScrollView
+import androidx.core.widget.NestedScrollView
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import io.github.kakaocup.kakao.common.actions.ScrollableActions
 import io.github.kakaocup.kakao.common.actions.SwipeableActions
 import org.hamcrest.Matchers
+import org.hamcrest.Matchers.anyOf
 
 /**
  * Provides ScrollableActions implementation for ScrollView
@@ -24,11 +28,20 @@ interface ScrollViewActions : ScrollableActions, SwipeableActions {
             override fun getDescription() = "Scroll ScrollView to start"
 
             override fun getConstraints() =
-                Matchers.allOf(ViewMatchers.isAssignableFrom(ScrollView::class.java), ViewMatchers.isDisplayed())
+                Matchers.allOf(
+                    anyOf(
+                        isAssignableFrom(ScrollView::class.java),
+                        isAssignableFrom(NestedScrollView::class.java),
+                        isAssignableFrom(HorizontalScrollView::class.java),
+                    ),
+                    ViewMatchers.isDisplayed()
+                )
 
             override fun perform(uiController: UiController?, view: View?) {
-                if (view is ScrollView) {
-                    view.fullScroll(View.FOCUS_UP)
+                when (view) {
+                    is ScrollView -> view.fullScroll(View.FOCUS_UP)
+                    is NestedScrollView -> view.fullScroll(View.FOCUS_UP)
+                    is HorizontalScrollView -> view.fullScroll(View.FOCUS_LEFT)
                 }
             }
         })
@@ -39,11 +52,20 @@ interface ScrollViewActions : ScrollableActions, SwipeableActions {
             override fun getDescription() = "Scroll ScrollView to end"
 
             override fun getConstraints() =
-                Matchers.allOf(ViewMatchers.isAssignableFrom(ScrollView::class.java), ViewMatchers.isDisplayed())
+                Matchers.allOf(
+                    anyOf(
+                        isAssignableFrom(ScrollView::class.java),
+                        isAssignableFrom(NestedScrollView::class.java),
+                        isAssignableFrom(HorizontalScrollView::class.java),
+                    ),
+                    ViewMatchers.isDisplayed()
+                )
 
             override fun perform(uiController: UiController?, view: View?) {
-                if (view is ScrollView) {
-                    view.fullScroll(View.FOCUS_DOWN)
+                when (view) {
+                    is ScrollView -> view.fullScroll(View.FOCUS_DOWN)
+                    is NestedScrollView -> view.fullScroll(View.FOCUS_DOWN)
+                    is HorizontalScrollView -> view.fullScroll(View.FOCUS_RIGHT)
                 }
             }
         })
@@ -54,11 +76,20 @@ interface ScrollViewActions : ScrollableActions, SwipeableActions {
             override fun getDescription() = "Scroll ScrollView to $position Y position"
 
             override fun getConstraints() =
-                Matchers.allOf(ViewMatchers.isAssignableFrom(ScrollView::class.java), ViewMatchers.isDisplayed())
+                Matchers.allOf(
+                    anyOf(
+                        isAssignableFrom(ScrollView::class.java),
+                        isAssignableFrom(NestedScrollView::class.java),
+                        isAssignableFrom(HorizontalScrollView::class.java),
+                    ),
+                    ViewMatchers.isDisplayed()
+                )
 
             override fun perform(uiController: UiController?, view: View?) {
-                if (view is ScrollView) {
-                    view.scrollTo(0, position)
+                when (view) {
+                    is ScrollView -> view.scrollTo(0, position)
+                    is NestedScrollView -> view.scrollTo(0, position)
+                    is HorizontalScrollView -> view.scrollTo(position, 0)
                 }
             }
         })

--- a/sample/src/androidTest/kotlin/io/github/kakaocup/sample/HorizontalScrollTest.kt
+++ b/sample/src/androidTest/kotlin/io/github/kakaocup/sample/HorizontalScrollTest.kt
@@ -1,0 +1,33 @@
+package io.github.kakaocup.sample
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
+import io.github.kakaocup.sample.screen.ScrollScreen
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class HorizontalScrollTest {
+    @Rule
+    @JvmField
+    val rule = ActivityScenarioRule(HorizontalScrollActivity::class.java)
+
+    @Test
+    fun test() {
+        onScreen<ScrollScreen> {
+            checkStart()
+            scroll { scrollToEnd() }
+            checkEnd()
+
+            scroll { scrollToStart() }
+            checkStart()
+
+            scroll { scrollTo(5000) }
+            checkEnd()
+        }
+    }
+}
+

--- a/sample/src/androidTest/kotlin/io/github/kakaocup/sample/NestedScrollTest.kt
+++ b/sample/src/androidTest/kotlin/io/github/kakaocup/sample/NestedScrollTest.kt
@@ -1,0 +1,33 @@
+package io.github.kakaocup.sample
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
+import io.github.kakaocup.sample.screen.ScrollScreen
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class NestedScrollTest {
+    @Rule
+    @JvmField
+    val rule = ActivityScenarioRule(NestedScrollActivity::class.java)
+
+    @Test
+    fun test() {
+        onScreen<ScrollScreen> {
+            checkStart()
+            scroll { scrollToEnd() }
+            checkEnd()
+
+            scroll { scrollToStart() }
+            checkStart()
+
+            scroll { scrollTo(5000) }
+            checkEnd()
+        }
+    }
+}
+

--- a/sample/src/androidTest/kotlin/io/github/kakaocup/sample/ScrollTest.kt
+++ b/sample/src/androidTest/kotlin/io/github/kakaocup/sample/ScrollTest.kt
@@ -1,0 +1,33 @@
+package io.github.kakaocup.sample
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import io.github.kakaocup.kakao.screen.Screen.Companion.onScreen
+import io.github.kakaocup.sample.screen.ScrollScreen
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class ScrollTest {
+    @Rule
+    @JvmField
+    val rule = ActivityScenarioRule(ScrollActivity::class.java)
+
+    @Test
+    fun test() {
+        onScreen<ScrollScreen> {
+            checkStart()
+            scroll { scrollToEnd() }
+            checkEnd()
+
+            scroll { scrollToStart() }
+            checkStart()
+
+            scroll { scrollTo(5000) }
+            checkEnd()
+        }
+    }
+}
+

--- a/sample/src/androidTest/kotlin/io/github/kakaocup/sample/screen/ScrollScreen.kt
+++ b/sample/src/androidTest/kotlin/io/github/kakaocup/sample/screen/ScrollScreen.kt
@@ -1,0 +1,33 @@
+package io.github.kakaocup.sample.screen
+
+import io.github.kakaocup.kakao.screen.Screen
+import io.github.kakaocup.kakao.scroll.KScrollView
+import io.github.kakaocup.kakao.text.KTextView
+import io.github.kakaocup.sample.R
+
+
+class ScrollScreen : Screen<ScrollScreen>() {
+    val firstElement = KTextView { withId(R.id.first_element) }
+    val secondElement = KTextView { withId(R.id.second_element) }
+    val scroll = KScrollView { withId(R.id.scroll) }
+
+    fun checkStart() {
+        idle(1000)
+        firstElement {
+            isDisplayed()
+        }
+        secondElement {
+            isNotDisplayed()
+        }
+    }
+
+    fun checkEnd() {
+        idle(1000)
+        firstElement {
+            isNotDisplayed()
+        }
+        secondElement {
+            isDisplayed()
+        }
+    }
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -40,6 +40,18 @@
         android:label="Nested Recycler Activity"
         android:theme="@style/AppTheme" />
     <activity
+        android:name="io.github.kakaocup.sample.NestedScrollActivity"
+        android:label="Nested scroll activity"
+        android:theme="@style/AppTheme" />
+    <activity
+        android:name="io.github.kakaocup.sample.HorizontalScrollActivity"
+        android:label="Horizontal scroll activity"
+        android:theme="@style/AppTheme" />
+    <activity
+        android:name="io.github.kakaocup.sample.ScrollActivity"
+        android:label="Scroll activity"
+        android:theme="@style/AppTheme" />
+    <activity
         android:name="io.github.kakaocup.sample.WebActivity"
         android:label="Web Activity"
         android:theme="@style/AppTheme" />

--- a/sample/src/main/kotlin/io/github/kakaocup/sample/HorizontalScrollActivity.kt
+++ b/sample/src/main/kotlin/io/github/kakaocup/sample/HorizontalScrollActivity.kt
@@ -1,0 +1,12 @@
+package io.github.kakaocup.sample
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class HorizontalScrollActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_horizontal_scroll)
+    }
+}

--- a/sample/src/main/kotlin/io/github/kakaocup/sample/NestedScrollActivity.kt
+++ b/sample/src/main/kotlin/io/github/kakaocup/sample/NestedScrollActivity.kt
@@ -1,0 +1,12 @@
+package io.github.kakaocup.sample
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class NestedScrollActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_nested_scroll)
+    }
+}

--- a/sample/src/main/kotlin/io/github/kakaocup/sample/ScrollActivity.kt
+++ b/sample/src/main/kotlin/io/github/kakaocup/sample/ScrollActivity.kt
@@ -1,0 +1,12 @@
+package io.github.kakaocup.sample
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class ScrollActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_nested_scroll)
+    }
+}

--- a/sample/src/main/res/layout/activity_horizontal_scroll.xml
+++ b/sample/src/main/res/layout/activity_horizontal_scroll.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+  <HorizontalScrollView
+      android:id="@+id/scroll"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+      <TextView
+          android:id="@+id/first_element"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="123" />
+
+      <View
+          android:layout_width="1000dp"
+          android:layout_height="wrap_content" />
+
+      <TextView
+          android:id="@+id/second_element"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="321" />
+    </LinearLayout>
+  </HorizontalScrollView>
+</LinearLayout>

--- a/sample/src/main/res/layout/activity_nested_scroll.xml
+++ b/sample/src/main/res/layout/activity_nested_scroll.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+  <androidx.core.widget.NestedScrollView
+      android:id="@+id/scroll"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+      <TextView
+          android:id="@+id/first_element"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="123" />
+
+      <View
+          android:layout_width="wrap_content"
+          android:layout_height="1000dp" />
+
+      <TextView
+          android:id="@+id/second_element"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="321" />
+    </LinearLayout>
+  </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/sample/src/main/res/layout/activity_scroll.xml
+++ b/sample/src/main/res/layout/activity_scroll.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+  <ScrollView
+      android:id="@+id/scroll"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+      <TextView
+          android:id="@+id/first_element"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="123" />
+
+      <View
+          android:layout_width="wrap_content"
+          android:layout_height="1000dp" />
+
+      <TextView
+          android:id="@+id/second_element"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="321" />
+    </LinearLayout>
+  </ScrollView>
+</LinearLayout>


### PR DESCRIPTION
Blind fix, I didn't test it.  Trying to fix exception below when trying to scroll to end NestedScrollView. While I'm at it, added HorizontalScrollVIew

```xml
<androidx.core.widget.NestedScrollView
    android:id="@+id/nested_scroll">
    ...
</androidx.core.widget.NestedScrollView
```

```kotlin
val scroll = KScrollView { withId(R.id.nested_scroll) }

scroll {
    scrollToEnd()
}
```

```
androidx.test.espresso.PerformException: Error performing 'Scroll ScrollView to end' on view '(view.getId() is <...id/nested_scroll>)'.
Caused by: java.lang.RuntimeException: Action will not be performed because the target view does not match one or more of the following constraints:
(is assignable from class <class android.widget.ScrollView> and (view has effective visibility <VISIBLE> and view.getGlobalVisibleRect() to return non-empty rectangle))
```