### PR TITLE
Fixed NPE inside DrawableMatcher

### DIFF
--- a/kakao/src/main/kotlin/io/github/kakaocup/kakao/common/matchers/DrawableMatcher.kt
+++ b/kakao/src/main/kotlin/io/github/kakaocup/kakao/common/matchers/DrawableMatcher.kt
@@ -63,11 +63,13 @@ class DrawableMatcher(
                 }
             }
 
-            if (expectedDrawable == null) {
-                return false
+            val actualDrawable: Drawable? = (imageView as ImageView).drawable
+
+            if (expectedDrawable == null || actualDrawable == null) {
+                return expectedDrawable == actualDrawable
             }
 
-            val convertDrawable = (imageView as ImageView).drawable.mutate()
+            val convertDrawable = actualDrawable.mutate()
             val bitmap = toBitmap?.invoke(convertDrawable) ?: convertDrawable.toBitmap()
 
             val otherBitmap = toBitmap?.invoke(expectedDrawable) ?: expectedDrawable.toBitmap()

--- a/sample/src/androidTest/kotlin/io/github/kakaocup/sample/EmptyDrawableMatcherTest.kt
+++ b/sample/src/androidTest/kotlin/io/github/kakaocup/sample/EmptyDrawableMatcherTest.kt
@@ -17,7 +17,6 @@ class EmptyDrawableMatcherTest {
     val rule = ActivityScenarioRule(EmptyImageViewActivity::class.java)
 
     @Test
-    @Ignore("DrawableMatcher needs to be fixed")
     fun test() {
         Screen.onScreen<EmptyImageViewScreen> {
             imageViewWithDrawable.isVisible()


### PR DESCRIPTION
- This PR fixes an NPE error inside `DrawableMatcher` that was mentioned in https://github.com/KakaoCup/Kakao/pull/143
- `EmptyDrawableMatcherTest#test` is now unignored, as it now passes successfully 